### PR TITLE
Use regen IRI for graph name.

### DIFF
--- a/pinning_service/graph.py
+++ b/pinning_service/graph.py
@@ -28,11 +28,11 @@ def add_graph_to_store(iri, serialized_graph, settings: Settings, format='applic
     store = create_sparql_store(settings)
     ds = Dataset(store=store)
     # add named graph to dataset
-    g = ds.add_graph(URIRef(f'{settings.GRAPH_DB_BASE_URL}/data/{iri}'))
+    g = ds.add_graph(URIRef(iri))
     g.parse(data=serialized_graph, format=format)
     # add triple to default graph manifest
     ds.add((
-        URIRef(f'{settings.GRAPH_DB_BASE_URL}/data/{iri}'),
+        URIRef(iri),
         URIRef('http://purl.org/dc/elements/1.1/date'),
         Literal(datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")),
     ))


### PR DESCRIPTION
Hey @wgardiner I'm curious if this makes sense, simply using the Regen IRI as the identifier for each named graph. Not sure how we missed it before but I think this makes the most sense. It seems weird to have the named graph be linked to an individual indexer.. Since this IRI is unique it should still be possible to use this as an identifier for the data/graph between multiple indexers.

![default_graph](https://user-images.githubusercontent.com/3116995/170804107-e60aca36-1e98-4e1a-b0d3-0306433fb37c.png)
![named_graph](https://user-images.githubusercontent.com/3116995/170804111-cd4be563-9aa6-4bca-9f3b-5e4d82de8ea9.png)
 