### PR TITLE
Query regen node for IRI using content hash graph

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -1,4 +1,5 @@
 DATABASE_URL = "sqlite:///./test.db"
+REGEN_NODE_REST_URL = "http://localhost:1317"
 GRAPH_DB_BASE_URL = "http://localhost:3030/resources"
 GRAPH_DB_USERNAME = "admin"
 GRAPH_DB_PASSWORD = "admin"

--- a/pinning_service/config.py
+++ b/pinning_service/config.py
@@ -10,6 +10,8 @@ class Settings(BaseSettings):
 
     DATABASE_URL: str
 
+    REGEN_NODE_REST_URL: AnyHttpUrl
+
     GRAPH_DB_BASE_URL: AnyHttpUrl = None
     GRAPH_DB_USERNAME: str = None
     GRAPH_DB_PASSWORD: str = None


### PR DESCRIPTION
This gets the true regen IRI by querying the a REST url for the iri with the content hash graph attributes. Closes #8

Unfortunately this requires a connection to a running regen node with the REST API enabled. I was hoping we could perform this "query" using the regen CLI but as currently implemented the CLI still sends the query to a running node.

@wgardiner this adds some complexity to our local environments because we'll need to be running a localnet in order to POST data but I think this is OK for now. Our MVP for anchoring data #7 will be simple and require that we have a localnet running anyways.